### PR TITLE
Add SSE support via uvicorn

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ A Model Context Protocol (MCP) server for log file management and analysis with 
    ```
    (You could also use sample logs in the logs folder to get started.)
 
-3. **Run the server:**
+3. **Run the server (SSE via uvicorn):**
    ```bash
    # Use default ./logs directory
    python mcp_server.py
+
+   # The server uses uvicorn and exposes an SSE endpoint at
+   # http://localhost:8000/log-server
    
    # Use custom logs directory (command line)
    python mcp_server.py /path/to/your/logs

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from mcp_server import server
-import asyncio
 
 if __name__ == "__main__":
-    asyncio.run(server.run())
+    server.run(transport="sse")

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -233,4 +233,4 @@ if __name__ == "__main__":
     print("📖 See README.md for how to set up Claude Desktop to use this server.")
     
     print("\n⏳ Waiting for connections...\n")
-    asyncio.run(server.run())
+    server.run(transport="sse")


### PR DESCRIPTION
## Summary
- run the log server using SSE transport
- update README instructions for running with uvicorn SSE

## Testing
- `python tests/test_basic.py`

------
https://chatgpt.com/codex/tasks/task_e_68467164c588832aa679d104908a5bb8